### PR TITLE
add env['omniauth.auth'] guard

### DIFF
--- a/lib/warden_omniauth.rb
+++ b/lib/warden_omniauth.rb
@@ -66,7 +66,7 @@ class WardenOmniAuth
 
       # set the user if one exists
       # otherwise, redirect for authentication
-      if user = (env['rack.auth'] || request['auth']) # TODO: Fix..  Completely insecure... do not use this will look in params for the auth.  Apparently fixed in the new gem
+      if user = (env['omniauth.auth'] || env['rack.auth'] || request['auth']) # TODO: Fix..  Completely insecure... do not use this will look in params for the auth.  Apparently fixed in the new gem
 
         success! self.class.on_callback[user]
       else


### PR DESCRIPTION
Hello, @hassox

I'm utilizing your gem and I feel it very convenient.

But I found that current omniauth gem puts the user information into `env['omniauth.auth']`, rather than `env['rack.auth']`.
So I have to make a monkey patch every time I use warden_omniauth...

Can you pull this small patch?
Thank you!
