### PR TITLE
major rework

### DIFF
--- a/warden_omniauth.gemspec
+++ b/warden_omniauth.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.rubyforge_project         = "warden_omniauth"
 
   s.add_dependency "omniauth"
-  s.add_dependency "warden", ">=0.9"
+  s.add_dependency "warden", ">=1.0.0"
 
   s.add_development_dependency "bundler", ">= 1.0.0"
 


### PR DESCRIPTION
- More robust as far as OmniAuth strategy names go - no more snake-case
  guessing.
- Make failure handling consistent - everything now goes through the
  same handling in warden, and adds OmniAuth's failure message into
  Warden's errors.
- Pass the strategy to the callback so the callback can know which
  OmniAuth strategy was used.
- Make the redirect on success callback a proc that gets 'env', to take
  advantage of things like omniauth.origin.
